### PR TITLE
Add explicit jaeger-agent location

### DIFF
--- a/week_7/grpc_with_traces/docker-compose.yaml
+++ b/week_7/grpc_with_traces/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     image: jaegertracing/all-in-one:1.48
     ports:
       - "5775:5775/udp"
-      - "6831:6831/udp"
+      - "6831:6831/udp" # jaeger-client
       - "6832:6832/udp"
       - "5778:5778"
       - "16686:16686" # web

--- a/week_7/grpc_with_traces/internal/tracing/tracing.go
+++ b/week_7/grpc_with_traces/internal/tracing/tracing.go
@@ -11,6 +11,9 @@ func Init(logger *zap.Logger, serviceName string) {
 			Type:  "const",
 			Param: 1,
 		},
+		Reporter: &config.ReporterConfig{
+			LocalAgentHostPort: "localhost:6831",
+		},
 	}
 
 	_, err := cfg.InitGlobalTracer(serviceName)


### PR DESCRIPTION
Added explicit option for jaeger-agent location to better understand where the connection between application and jaeger is set.
They are default values from `jaeger-client-go`:
- DefaultUDPSpanServerHost = "localhost" (https://github.com/jaegertracing/jaeger-client-go/blob/master/constants.go#L87)
- DefaultUDPSpanServerPort = 6831 (https://github.com/jaegertracing/jaeger-client-go/blob/master/constants.go#L90)

In cases where you don't need or can't work with default values (e.g. your application and jaeger both are docker containers), please make sure to change LocalAgentHostPort to appropriate values.